### PR TITLE
docs: backfill real 1.0.1 CHANGELOG entry, drop phantom 1.0.0-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,26 @@
 # @vex-chat/types
 
-## 1.0.0-rc.2
+## 1.0.1
 
-### Minor Changes
+### Patch Changes
 
-- Add platform adapter types and unify tooling.
+- Platform adapter types, sourcemaps, tarball hygiene, and tooling cleanup.
 
-    **New types**:
-    - `IUser` / `IUserRecord` split — `IUser` is the public-facing shape, `IUserRecord` extends it with DB fields
-    - `KeyStore` and `StoredCredentials` interfaces for platform-agnostic key storage
+    **Type surface** (runtime-safe, but may require type updates in consumers):
+    - `BaseMsg.data` changed from `Buffer` to `Uint8Array`. `Buffer` is Node-only and blocked browser consumers; `Uint8Array` is a supertype of `Buffer` at runtime, so existing Node callers keep working, but code that was typed against `Buffer` needs updating.
+    - `IUser` / `IUserRecord` split — `IUser` is the public-facing shape (`userID`, `username`, `lastSeen`); `IUserRecord` extends it with DB-only fields (`passwordHash`, `passwordSalt`). Previously conflated.
+    - New `KeyStore` interface (`load` / `save` / `clear`) and `StoredCredentials` interface (`username`, `deviceID`, `deviceKey`, `preKey?`, `token?`) for platform-agnostic key storage.
+    - Sourcemaps (`.js.map` + `.d.ts.map`) now ship in `dist/`.
+
+    **Packaging**:
+    - Added `files: ["dist"]` — the published tarball is now limited to `dist/` + `LICENSE` + `README.md` + `package.json`. Previously leaked `CHANGELOG.md`, `RELEASING.md`, `eslint.config.js`, `mise.toml`, `.husky/`, and `.changeset/`.
 
     **Tooling**:
-    - Strict tsconfig (es2024 target, full strict flags)
-    - Unified formatting: prettier 4-space tabs, eslint flat config, removed tslint
-    - Consistent scripts: `format`, `format:check`, `lint`, `lint:fix`
+    - Strict tsconfig (es2024 target, full strict flags).
+    - Unified formatting: prettier 4-space tabs, eslint flat config, removed tslint.
+    - `build` no longer `rimraf`s first (preserves hardlinks / incremental builds). `build:clean` added for full rebuilds.
+    - Scripts renamed for consistency: `format` / `format:check` (was `prettier`), `lint:fix` (was `lint-fix`).
+    - `lint-staged` glob fixed from `src/**/*.{ts}` to `*.ts` and now also runs prettier.
 
 ## 1.0.0-rc.1
 


### PR DESCRIPTION
The top CHANGELOG entry on master was labelled 1.0.0-rc.2, but that version was never published to npm — the content actually shipped as part of 1.0.1, which was published manually without a matching CHANGELOG entry. Verified by comparing the 1.0.0-rc.1 and 1.0.1 tarballs on the npm registry.

Rewrite the phantom rc.2 entry as a real 1.0.1 entry, and expand it to cover everything the tarball diff actually shows:

- `BaseMsg.data: Buffer` → `Uint8Array` (runtime-safe, browser- compatible, but a typed breaking change)
- `IUser` / `IUserRecord` split
- New `KeyStore` and `StoredCredentials` interfaces
- Sourcemaps now ship in dist/
- `files: ["dist"]` added — previously the tarball was leaking CHANGELOG.md, RELEASING.md, eslint.config.js, mise.toml, .husky/, and .changeset/
- Build/format/lint script cleanups

Heading uses `### Patch Changes` to match what changesets would have generated for a 1.0.0 → 1.0.1 patch bump. Semver-wise 1.0.1 should arguably have been 1.1.0 (new interfaces) or 2.0.0 (typed breaking change on BaseMsg.data), but the published version number is what it is — we just document it accurately.